### PR TITLE
Appears environment variables are already evaluated on build without …

### DIFF
--- a/MacroUI/Program.cs
+++ b/MacroUI/Program.cs
@@ -21,6 +21,7 @@ namespace MacroUI
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
                     webBuilder.UseStartup<Startup>();
+                    webBuilder.UseIIS();
                 });
     }
 }


### PR DESCRIPTION
…the hard "AddEnvironmentVariables()"